### PR TITLE
fix(sidebar): inherit color from itemgroup/menu (it not provided)

### DIFF
--- a/libs/flowbite-angular/src/lib/components/sidebar/sidebar-item.component.ts
+++ b/libs/flowbite-angular/src/lib/components/sidebar/sidebar-item.component.ts
@@ -12,7 +12,14 @@ import { SidebarMenuComponent } from './sidebar-menu.component';
 import type { SidebarColors } from './sidebar.theme';
 
 import { NgClass, NgIf } from '@angular/common';
-import { Component, HostListener, inject, input, signal } from '@angular/core';
+import {
+  Component,
+  computed,
+  HostListener,
+  inject,
+  input,
+  signal
+} from '@angular/core';
 
 @Component({
   standalone: true,
@@ -45,25 +52,44 @@ export class SidebarItemComponent extends BaseComponent {
   public readonly flowbiteRouterLink = inject(FlowbiteRouterLinkDirective);
   public readonly flowbiteRouterLinkActive = inject(FlowbiteRouterLinkActiveDirective);
   public readonly themeService = inject(SidebarItemThemeService);
-  public readonly sidebarItemGroupComponent = inject<SidebarItemGroupComponent | undefined>(SidebarItemGroupComponent);
+  public readonly sidebarItemGroupComponent = inject<SidebarItemGroupComponent | undefined>(SidebarItemGroupComponent, { optional: true });
   public readonly sidebarMenuComponent = inject<SidebarMenuComponent | undefined>(SidebarMenuComponent);
 
   public override contentClasses = signal<SidebarItemClass>(createClass({ rootClass: '', sidebarIconClass: '' }));
 
   //#region properties
   public icon = input<string | undefined>(undefined);
-  public color = input<keyof SidebarColors>(
-    (this.sidebarItemGroupComponent?.sidebarMenuComponent || this.sidebarMenuComponent)!.color(),
-  );
+  public color = input<keyof SidebarColors>();
   public label = input<string | undefined>(undefined);
   public customStyle = input<DeepPartial<SidebarItemTheme>>({});
+
+  // With a computed, it's possible to dynamically
+  // change the color (even if the SidebarMenuComponent's
+  // or SidebarItemGroupComponent's color has changed)
+  private realColor = computed(() => {
+    // If the color is set directly on the
+    // SidebarItemComponent we just return it as is
+    if (this.color() !== undefined) {
+      return this.color() as keyof SidebarColors;
+    }
+
+    // If the component is inside a SidebarItemGroupComponent
+    // we return it's color
+    if (this.sidebarItemGroupComponent) {
+      return this.sidebarItemGroupComponent.color();
+    }
+
+    // Since a SidebarMenuComponent is required, we return
+    // its color if none of the above conditions are met
+    return this.sidebarMenuComponent?.color() ?? 'primary';
+  });
   //#endregion
 
   //#region BaseComponent implementation
   public override fetchClass(): void {
     const propertyClass = this.themeService.getClasses({
       icon: this.icon(),
-      color: this.color(),
+      color: this.realColor(),
       label: this.label(),
       customStyle: this.customStyle(),
     });
@@ -72,8 +98,8 @@ export class SidebarItemComponent extends BaseComponent {
   }
 
   public override verify(): void {
-    if (this.sidebarMenuComponent === undefined && this.sidebarItemGroupComponent === undefined) {
-      throw new Error('No SidebarMenuComponent/SidebarItemGroupComponent available');
+    if (this.sidebarMenuComponent === undefined) {
+      throw new Error('No SidebarMenuComponent available');
     }
   }
   //#endregion

--- a/libs/flowbite-angular/src/lib/components/sidebar/sidebar-item.component.ts
+++ b/libs/flowbite-angular/src/lib/components/sidebar/sidebar-item.component.ts
@@ -78,8 +78,8 @@ export class SidebarItemComponent extends BaseComponent {
   }
 
   public override verify(): void {
-    if (this.sidebarMenuComponent === undefined) {
-      throw new Error('No SidebarMenuComponent available');
+    if (this.sidebarMenuComponent === undefined && this.sidebarItemGroupComponent === undefined) {
+      throw new Error('No SidebarMenuComponent/SidebarItemGroupComponent available');
     }
   }
   //#endregion

--- a/libs/flowbite-angular/src/lib/components/sidebar/sidebar-item.component.ts
+++ b/libs/flowbite-angular/src/lib/components/sidebar/sidebar-item.component.ts
@@ -14,7 +14,6 @@ import type { SidebarColors } from './sidebar.theme';
 import { NgClass, NgIf } from '@angular/common';
 import {
   Component,
-  computed,
   HostListener,
   inject,
   input,
@@ -59,37 +58,18 @@ export class SidebarItemComponent extends BaseComponent {
 
   //#region properties
   public icon = input<string | undefined>(undefined);
-  public color = input<keyof SidebarColors>();
+  public color = input<keyof SidebarColors>(
+    (this.sidebarItemGroupComponent ?? this.sidebarMenuComponent)!.color()
+  );
   public label = input<string | undefined>(undefined);
   public customStyle = input<DeepPartial<SidebarItemTheme>>({});
-
-  // With a computed, it's possible to dynamically
-  // change the color (even if the SidebarMenuComponent's
-  // or SidebarItemGroupComponent's color has changed)
-  private realColor = computed(() => {
-    // If the color is set directly on the
-    // SidebarItemComponent we just return it as is
-    if (this.color() !== undefined) {
-      return this.color() as keyof SidebarColors;
-    }
-
-    // If the component is inside a SidebarItemGroupComponent
-    // we return it's color
-    if (this.sidebarItemGroupComponent) {
-      return this.sidebarItemGroupComponent.color();
-    }
-
-    // Since a SidebarMenuComponent is required, we return
-    // its color if none of the above conditions are met
-    return this.sidebarMenuComponent?.color() ?? 'primary';
-  });
   //#endregion
 
   //#region BaseComponent implementation
   public override fetchClass(): void {
     const propertyClass = this.themeService.getClasses({
       icon: this.icon(),
-      color: this.realColor(),
+      color: this.color(),
       label: this.label(),
       customStyle: this.customStyle(),
     });


### PR DESCRIPTION
Added `optional` parameter to the SidebarItemGroupComponent, so it's possibly to create a "simple" sidebar items without dropdowns (e.g. Logout button). Also removed the check it's existence from the `verify()` function.

Removed the default value of `color` input, and created a private computed to use in `fetchClass()`.
- In this case if the `color` is set it'll be the value
- If the `color` is not set, and a SidebarItemGroupComponent exists, it'll be the group's color
- Otherwise it'll be the SidebarMenuComponent's color, since it's required

---
```html
<flowbite-sidebar isOpen class="min-h-screen">
    <flowbite-sidebar-menu class="w-64" color="green">
      <flowbite-sidebar-item-group
        isOpen
        title="Group 1"
        color="red">
        <flowbite-sidebar-item>Menu 1</flowbite-sidebar-item>
        <flowbite-sidebar-item color="yellow">Menu 2</flowbite-sidebar-item>
      </flowbite-sidebar-item-group>

      <flowbite-sidebar-item-group
        isOpen
        title="Group 2"
        color="blue">
        <flowbite-sidebar-item>Menu 3</flowbite-sidebar-item>
        <flowbite-sidebar-item color="yellow">Menu 4</flowbite-sidebar-item>
      </flowbite-sidebar-item-group>

      <flowbite-sidebar-item-group
        isOpen
        title="Group 3">
        <flowbite-sidebar-item>Menu 5</flowbite-sidebar-item>
        <flowbite-sidebar-item color="yellow">Menu 6</flowbite-sidebar-item>
      </flowbite-sidebar-item-group>

      <flowbite-sidebar-item>Menu 7</flowbite-sidebar-item>
    </flowbite-sidebar-menu>

    <flowbite-sidebar-page-content class="p-4">
      Hello world!
    </flowbite-sidebar-page-content>
</flowbite-sidebar>
```
In this example the SidebarItems color's will look like this:
- Menu 1: red - inherited from Group 1
- Menu 2: yellow - directly set
- Menu 3: blue - inherited from Group 2
- Menu 4: yellow - directly set
- Menu 5: ~~primary - inherited from SidebarItemGroup~~ green from SidebarMenu (Edit: somehow i messed up something, it looks good to me)
- Menu 6: yellow - directly set
- Menu 7: green - inherited from SidebarMenu
