### PR TITLE
fix(docs): revert `ul` and `ol` only outside of `flowbite-dropdown` #59

### DIFF
--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -6,8 +6,8 @@
 @tailwind base;
 
 @layer base {
-  ul,
-  ol {
+  ul:not(flowbite-dropdown ul),
+  ol:not(flowbite-dropdown ol) {
     list-style: revert;
     margin: revert;
     padding: revert;


### PR DESCRIPTION
Since the issue was only related to the docs page it's enough to revert the `ul` and `ol` tags which are not inside a dropdown. In this case the pages generated by NgDoc are fine.